### PR TITLE
CI: Remove `touch` hack and deprecated+useless `actions-rs` steps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,32 +7,13 @@ jobs:
     name: Check and Lint
     strategy:
       matrix:
-        os: [windows-latest]
-        rust: [stable]
+        os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          override: true
-          components: rustfmt, clippy
       - name: Cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --workspace --all-targets
+        run: cargo check --workspace --all-targets
       - name: Cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-      # Update mtime on all our files so that `clippy` rechecks them
-      - name: Touch source files for clippy recheck
-        run: find -path ./target -prune -o -name "*.rs" -exec touch {} +
-        shell: bash
+        run: cargo fmt --all -- --check
       - name: Cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings


### PR DESCRIPTION
hassle-rs got this >1 year ago: https://github.com/Traverse-Research/hassle-rs/commit/5cd04858

And also remove bloated `actions-rs` steps and replace them with straightforward, recognizable `run: cargo ...`, same as https://github.com/Traverse-Research/hassle-rs/pull/63.
