### PR TITLE
Fix blosc decompression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ debug = true
 [dependencies]
 bitflags = "1"
 bitvec = "1"
-blosc-src = "0.1.1"
+blosc-src = { git = "https://github.com/jasperdewinther/rust-blosc-src.git"} # until https://github.com/mulimoen/rust-blosc-src/pull/2
 bytemuck = { version = "1.13", features = ["extern_crate_alloc"] }
 byteorder = "1.4"
 flate2 = "1"

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -97,14 +97,6 @@ fn read_transform<R: Read + Seek>(reader: &mut R) -> Result<Map, ParseError> {
             inv_scale_sqr: read_d_vec3(reader)?,
             inv_twice_scale: read_d_vec3(reader)?,
         },
-        "ScaleTranslateMap" => Map::ScaleTranslateMap {
-            translation: read_d_vec3(reader)?,
-            scale_values: read_d_vec3(reader)?,
-            voxel_size: read_d_vec3(reader)?,
-            scale_values_inverse: read_d_vec3(reader)?,
-            inv_scale_sqr: read_d_vec3(reader)?,
-            inv_twice_scale: read_d_vec3(reader)?,
-        },
         v => panic!("Not supported {}", v),
     })
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -96,6 +96,14 @@ fn read_transform<R: Read + Seek>(reader: &mut R) -> Result<Map, ParseError> {
             inv_scale_sqr: read_d_vec3(reader)?,
             inv_twice_scale: read_d_vec3(reader)?,
         },
+        "ScaleTranslateMap" => Map::ScaleTranslateMap {
+            translation: read_d_vec3(reader)?,
+            scale_values: read_d_vec3(reader)?,
+            voxel_size: read_d_vec3(reader)?,
+            scale_values_inverse: read_d_vec3(reader)?,
+            inv_scale_sqr: read_d_vec3(reader)?,
+            inv_twice_scale: read_d_vec3(reader)?,
+        },
         v => panic!("Not supported {}", v),
     })
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -15,4 +15,12 @@ pub enum Map {
         inv_scale_sqr: glam::DVec3,
         inv_twice_scale: glam::DVec3,
     },
+    ScaleTranslateMap {
+        translation: glam::DVec3,
+        scale_values: glam::DVec3,
+        voxel_size: glam::DVec3,
+        scale_values_inverse: glam::DVec3,
+        inv_scale_sqr: glam::DVec3,
+        inv_twice_scale: glam::DVec3,
+    },
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -15,12 +15,4 @@ pub enum Map {
         inv_scale_sqr: glam::DVec3,
         inv_twice_scale: glam::DVec3,
     },
-    ScaleTranslateMap {
-        translation: glam::DVec3,
-        scale_values: glam::DVec3,
-        voxel_size: glam::DVec3,
-        scale_values_inverse: glam::DVec3,
-        inv_scale_sqr: glam::DVec3,
-        inv_twice_scale: glam::DVec3,
-    },
 }


### PR DESCRIPTION
This change switches to a version of blosc-src which makes use of cc instead of cmake. This simplifies the building process. It also fixes a bug which had to do with us not using `blosc_cbuffer_sizes` to get the correct vector size.

This change enables files which are exported by houdini to be loaded.