### PR TITLE
Use published `blosc` crate instead of `git` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,7 @@ debug = true
 [dependencies]
 bitflags = "1"
 bitvec = "1"
-# https://github.com/mulimoen/rust-blosc-src/pull/2
-blosc-src = { git = "https://github.com/jasperdewinther/rust-blosc-src", features = ["lz4", "zlib", "zstd"] }
+blosc-src = { version = "0.2.1", features = ["lz4", "zlib", "zstd"] }
 bytemuck = { version = "1.13", features = ["extern_crate_alloc"] }
 byteorder = "1.4"
 flate2 = "1"


### PR DESCRIPTION
now using crates.io blosc crate