### PR TITLE
remove unused blosc deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ debug = true
 [dependencies]
 bitflags = "1"
 bitvec = "1"
-blosc-src = { version = "0.2.1", features = ["lz4", "zlib", "zstd"] }
+blosc-src = { version = "0.2.1", features = ["lz4"] }
 bytemuck = { version = "1.13", features = ["extern_crate_alloc"] }
 byteorder = "1.4"
 flate2 = "1"

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -137,7 +137,7 @@ fn read_compressed_data<R: Read + Seek, T: Pod>(
         let num_compressed_bytes = reader.read_i64::<LittleEndian>()?;
         let compressed_count = num_compressed_bytes / std::mem::size_of::<T>() as i64;
 
-        trace!("Reading blocs data, {} bytes", num_compressed_bytes);
+        trace!("Reading blosc data, {} bytes", num_compressed_bytes);
         if num_compressed_bytes <= 0 {
             let mut data = vec![T::zeroed(); (-compressed_count) as usize];
             reader.read_exact(cast_slice_mut(&mut data))?;


### PR DESCRIPTION
Only lz4 is used in certain scenarios (for example when exporting from Houdini), the zstd and zlib deps can be removed as they will never be used.