### PR TITLE
Upgrade to `bevy 0.10` and use `Unreal` camera controller

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,4 @@ thiserror = "1"
 [dev-dependencies]
 bevy = { version = "0.9", default-features = false, features = ["bevy_pbr"] }
 bevy-aabb-instancing = { git = "https://github.com/ForesightMiningSoftwareCorporation/bevy-aabb-instancing.git", rev = "fdb22b96dd3bc0c98430221c425fa83fc5ad001b" }
-bevy_flycam = "0.9"
 smooth-bevy-cameras = { git = "https://github.com/olegomon/smooth-bevy-cameras", rev = "331959876e1c940f04e3701b214fa05ee7936384" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,6 @@ log = "0.4"
 thiserror = "1"
 
 [dev-dependencies]
-bevy = { version = "0.9", default-features = false, features = ["bevy_pbr"] }
+bevy = { version = "0.10", default-features = false, features = ["bevy_pbr"] }
 bevy-aabb-instancing = { git = "https://github.com/ForesightMiningSoftwareCorporation/bevy-aabb-instancing.git", rev = "fdb22b96dd3bc0c98430221c425fa83fc5ad001b" }
 smooth-bevy-cameras = { git = "https://github.com/olegomon/smooth-bevy-cameras", rev = "331959876e1c940f04e3701b214fa05ee7936384" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,5 @@ thiserror = "1"
 
 [dev-dependencies]
 bevy = { version = "0.10", default-features = false, features = ["bevy_pbr"] }
-bevy-aabb-instancing = { git = "https://github.com/ForesightMiningSoftwareCorporation/bevy-aabb-instancing.git", rev = "fdb22b96dd3bc0c98430221c425fa83fc5ad001b" }
-smooth-bevy-cameras = { git = "https://github.com/olegomon/smooth-bevy-cameras", rev = "331959876e1c940f04e3701b214fa05ee7936384" }
+bevy-aabb-instancing = "0.9"
+smooth-bevy-cameras = "0.8"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ☁️ `vdb-rs`
 ========
+
 [![Actions Status](https://github.com/Traverse-Research/vdb-rs/workflows/Continuous%20integration/badge.svg)](https://github.com/Traverse-Research/vdb-rs/actions)
 [![Latest version](https://img.shields.io/crates/v/vdb-rs.svg)](https://crates.io/crates/vdb-rs)
 [![Documentation](https://docs.rs/vdb-rs/badge.svg)](https://docs.rs/vdb-rs)
@@ -36,7 +37,7 @@ Implementation of features however is use-case limited, so contributions in area
 
 # Broken files
 
-These are test files from the OpenVDB website; https://www.openvdb.org/download/. Most file seem to be loading correctly
+These are test files from the OpenVDB website; <https://www.openvdb.org/download/>. Most file seem to be loading correctly
 and displaying correctly in the `bevy` example that's provided with this library.
 
 Most of these errors seem to be related to the lack of Multi-Pass I/O, though most need to be investigated.

--- a/examples/bevy.rs
+++ b/examples/bevy.rs
@@ -3,7 +3,7 @@ use bevy_aabb_instancing::{
     Cuboid, CuboidMaterial, CuboidMaterialMap, Cuboids, ScalarHueOptions,
     VertexPullingRenderPlugin, COLOR_MODE_SCALAR_HUE,
 };
-use smooth_bevy_cameras::{controllers::fps::*, LookTransformPlugin};
+use smooth_bevy_cameras::{controllers::unreal::*, LookTransformPlugin};
 use vdb_rs::{read_vdb, Index, Node};
 
 use std::{error::Error, fs::File, io::BufReader};
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }))
         .add_plugin(VertexPullingRenderPlugin { outlines: true })
         .add_plugin(LookTransformPlugin)
-        .add_plugin(FpsCameraPlugin::default())
+        .add_plugin(UnrealCameraPlugin::default())
         .add_startup_system(setup)
         .run();
 
@@ -117,11 +117,8 @@ fn setup(
 
     commands
         .spawn(Camera3dBundle::default())
-        .insert(FpsCameraBundle::new(
-            FpsCameraController {
-                translate_sensitivity: 2.0,
-                ..Default::default()
-            },
+        .insert(UnrealCameraBundle::new(
+            UnrealCameraController::default(),
             Vec3::new(0.0, 1.0, 10.0),
             Vec3::ZERO,
             Vec3::Y,

--- a/examples/bevy.rs
+++ b/examples/bevy.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy_aabb_instancing::{
-    ColorOptions, ColorOptionsMap, Cuboid, Cuboids, ScalarHueColorOptions,
+    Cuboid, CuboidMaterial, CuboidMaterialMap, Cuboids, ScalarHueOptions,
     VertexPullingRenderPlugin, COLOR_MODE_SCALAR_HUE,
 };
 use smooth_bevy_cameras::{controllers::fps::*, LookTransformPlugin};
@@ -11,10 +11,10 @@ use std::{error::Error, fs::File, io::BufReader};
 fn main() -> Result<(), Box<dyn Error>> {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
-            window: WindowDescriptor {
+            primary_window: Some(Window {
                 title: "VDB Viewer".into(),
                 ..Default::default()
-            },
+            }),
             ..Default::default()
         }))
         .add_plugin(VertexPullingRenderPlugin { outlines: true })
@@ -31,19 +31,18 @@ fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    mut color_options_map: ResMut<ColorOptionsMap>,
+    mut color_options_map: ResMut<CuboidMaterialMap>,
 ) {
-    let color_options_id = color_options_map.push(ColorOptions {
-        scalar_hue: ScalarHueColorOptions {
+    let color_options_id = color_options_map.push(CuboidMaterial {
+        color_mode: COLOR_MODE_SCALAR_HUE,
+        scalar_hue: ScalarHueOptions {
             min_visible: -10000.0,
             max_visible: 10000.0,
             clamp_min: -1.0,
             clamp_max: 0.5,
-            hue_zero: 240.0,
-            hue_slope: -300.0,
+            ..Default::default()
         },
-        color_mode: COLOR_MODE_SCALAR_HUE,
-        wireframe: 0,
+        ..Default::default()
     });
 
     let filename = std::env::args()
@@ -80,9 +79,6 @@ fn setup(
                             c * 0.01,
                             (c + bevy::prelude::Vec3::new(1.0, 1.0, 1.0)) * 0.01,
                             u32::from_le_bytes(f32::to_le_bytes(v.to_f32())),
-                            // v,
-                            true,
-                            idx as u16,
                         ));
                     }
                 } else {
@@ -127,7 +123,8 @@ fn setup(
                 ..Default::default()
             },
             Vec3::new(0.0, 1.0, 10.0),
-            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::ZERO,
+            Vec3::Y,
         ));
 }
 

--- a/examples/bevy.rs
+++ b/examples/bevy.rs
@@ -46,11 +46,9 @@ fn setup(
         wireframe: 0,
     });
 
-    let filename = if let Some(filename) = std::env::args().nth(1) {
-        filename
-    } else {
-        panic!("Invalid argument");
-    };
+    let filename = std::env::args()
+        .nth(1)
+        .expect("Missing VDB filename as first argument");
 
     let f = File::open(filename).unwrap();
     let mut reader = BufReader::new(f);


### PR DESCRIPTION
- Remove unused `bevy_flycam` crate
- Update bevy requirement from 0.9 to 0.10
- cargo: Update bevy plugin forks to `0.10`-compatible crates.io releases
- bevy: Switch to Unreal camera controller
