### PR TITLE
Revert "Update glam requirement from 0.23 to 0.24"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ blosc-src = { version = "0.2.1", features = ["lz4"] }
 bytemuck = { version = "1.13", features = ["extern_crate_alloc"] }
 byteorder = "1.4"
 flate2 = "1"
-glam = "0.24"
+glam = "0.23"
 half = { version = "2.2.1", features = ["bytemuck"] }
 log = "0.4"
 thiserror = "1"


### PR DESCRIPTION
I think we should hold back on this until the ecosystem catches up a bit more. 
Otherwise it is very easy to stumble into clashes with other dependencies like `nalgebra`  (still pending approval https://github.com/dimforge/nalgebra/pull/1242) and `parry` (https://github.com/dimforge/parry) which also depends on `nalgebra` and will have to update its glam dependency once the `nalgebra` PR goes in.
