### PR TITLE
🌪️ Load all grid descriptors in VDB and forcefully pick the "density" grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ and displaying correctly in the `bevy` example that's provided with this library
 Most of these errors seem to be related to the lack of Multi-Pass I/O, though most need to be investigated.
 
 1. no visuals: "smoke2.vdb-1.0.0/smoke2.vdb"
-1. parse error: "torus.vdb-1.0.0/torus.vdb" InvalidNodeMetadata
-1. parse erorr: "venusstatue.vdb-1.0.0/venusstatue.vdb" InvalidNodeMetadata
 1. parse error: "boat_points.vdb-1.0.0/boat_points.vdb" InvalidCompression
 1. parse error: "bunny_points.vdb-1.0.0/bunny_points.vdb" InvalidCompression
 1. parse error: "sphere_points.vdb-1.0.0/sphere_points.vdb" InvalidCompression

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -81,13 +81,17 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GridDescriptor {
     pub name: String,
-    pub grid_type: String,
+    /// If not empty, the name of another grid that shares this grid's tree
     pub instance_parent: String,
+    pub grid_type: String,
+    /// Location in the stream where the grid data is stored
     pub grid_pos: u64,
+    /// Location in the stream where the grid blocks are stored
     pub block_pos: u64,
+    /// Location in the stream where the next grid descriptor begins
     pub end_pos: u64,
     pub compression: Compression,
     pub meta_data: Metadata,
@@ -109,7 +113,7 @@ impl GridDescriptor {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Metadata(pub HashMap<String, MetadataValue>);
 
 impl Metadata {
@@ -118,11 +122,13 @@ impl Metadata {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum MetadataValue {
     String(String),
     Vec3i(glam::IVec3),
+    I32(i32),
     I64(i64),
+    Float(f32),
     Bool(bool),
     Unknown { name: String, data: Vec<u8> },
 }
@@ -254,12 +260,19 @@ bitflags! {
 
 #[derive(Debug)]
 pub struct ArchiveHeader {
+    /// The version of the file that was read
     pub file_version: u32,
+    /// The version of the library that was used to create the file that was read
     pub library_version_major: u32,
     pub library_version_minor: u32,
-    pub has_grid_offsets: bool,
-    pub compression: Compression,
+    /// Unique tag, a random 16-byte (128-bit) value, stored as a string format.
     pub guid: String,
-    pub meta_data: Metadata,
+    /// Flag indicating whether the input stream contains grid offsets and therefore supports partial reading
+    pub has_grid_offsets: bool,
+    /// Flags indicating whether and how the data stream is compressed
+    pub compression: Compression,
+    /// the number of grids on the input stream
     pub grid_count: u32,
+    /// The metadata for the input stream
+    pub meta_data: Metadata,
 }


### PR DESCRIPTION
Previously, this crate was loading the first grid descriptor found in the VDB file and its associated grid with the assumption that the first grid would be the density grid.
In this PR, I rework the loading code a bit to load all of the grid descriptors and then forcefully pick the one named "density". An error is returned for the time being if the "density" grid is not found.
This is a stepping stone towards a bigger refactor, since we'll have to modify the API a bit to expand the crate to support loading of all the grids.

Additional changes in this PR:
- Add support for reading `MetadataValue` of types `I32` and `Float`
- Add some comments to the struct fields as seen in the reference implementation

Possible ways to move forward:
- Load all grids and store in a hashmap, this is complicated by the necessity to define a type/format for the grid data through the generic argument
- Expose a `read_grid(name)` style of API, allowing the users to load only the grids they need. The generic argument can then be defined on the `read_grid` call.
- Other (suggestions?)