### PR TITLE
🦖 Refactor crate away from typed grids

### DIFF
--- a/examples/bevy.rs
+++ b/examples/bevy.rs
@@ -56,9 +56,9 @@ fn setup(mut commands: Commands, mut color_options_map: ResMut<CuboidMaterialMap
         grid_names.first().cloned().unwrap_or(String::new())
     });
 
-    let grid = vdb_reader.read_grid::<half::f16>(&grid_to_load).unwrap();
+    let grid = vdb_reader.read_grid(&grid_to_load).unwrap();
     let instances: Vec<Cuboid> = grid
-        .iter()
+        .iter::<half::f16>()
         .map(|(pos, voxel)| {
             Cuboid::new(
                 pos * 0.1,

--- a/examples/bevy.rs
+++ b/examples/bevy.rs
@@ -57,16 +57,28 @@ fn setup(mut commands: Commands, mut color_options_map: ResMut<CuboidMaterialMap
     });
 
     let grid = vdb_reader.read_grid(&grid_to_load).unwrap();
-    let instances: Vec<Cuboid> = grid
-        .iter::<half::f16>()
-        .map(|(pos, voxel)| {
-            Cuboid::new(
-                pos * 0.1,
-                (pos + Vec3::new(1.0, 1.0, 1.0)) * 0.1,
-                u32::from_le_bytes(f32::to_le_bytes(voxel.to_f32())),
-            )
-        })
-        .collect();
+    let grid_iter_variant = grid.iter();
+    let instances: Vec<Cuboid> = match grid_iter_variant {
+        vdb_rs::GridIterVariant::F32(iter) => iter
+            .map(|(pos, voxel)| {
+                Cuboid::new(
+                    pos * 0.1,
+                    (pos + Vec3::new(1.0, 1.0, 1.0)) * 0.1,
+                    u32::from_le_bytes(f32::to_le_bytes(voxel)),
+                )
+            })
+            .collect(),
+        vdb_rs::GridIterVariant::F16(iter) => iter
+            .map(|(pos, voxel)| {
+                Cuboid::new(
+                    pos * 0.1,
+                    (pos + Vec3::new(1.0, 1.0, 1.0)) * 0.1,
+                    u32::from_le_bytes(f32::to_le_bytes(voxel.to_f32())),
+                )
+            })
+            .collect(),
+    };
+
     let cuboids = Cuboids::new(instances);
     let aabb = cuboids.aabb();
     commands

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -41,7 +41,7 @@ impl Grid {
             node_4: None,
             node_3: None,
 
-            phantom: PhantomData::default(),
+            phantom: PhantomData::<ValueTy>,
         }
     }
 
@@ -91,7 +91,7 @@ pub struct GridIter<'a, ValueTy> {
     node_4: Option<&'a Node4>,
     node_3: Option<&'a Node3>,
 
-    phantom: PhantomData<ValueTy>, // TODO: rm
+    phantom: PhantomData<ValueTy>,
 }
 
 impl<'a, ValueTy> Iterator for GridIter<'a, ValueTy>
@@ -104,9 +104,7 @@ where
         loop {
             if let (Some(idx), Some(node_3)) = (self.node_3_iter.next(), self.node_3) {
                 // TODO: Cast when GridIter is created? Not at every iteration? Or is that not an issue?
-                let typed_data_vec: Vec<ValueTy> =
-                    bytemuck::cast_slice::<u8, ValueTy>(&node_3.buffer).to_vec();
-                let v = typed_data_vec[idx];
+                let v = bytemuck::cast_slice::<u8, ValueTy>(&node_3.buffer)[idx];
                 let global_coord = node_3.offset_to_global_coord(Index(idx as u32));
                 let c = global_coord.0.as_vec3();
                 return Some((c, v));

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -15,10 +15,10 @@ pub enum GridMetadataError {
     FieldNotPresent(String),
 }
 
+// TODO: Only implemented the types I could find in a file up until now
 pub enum LeafDataType {
     F32,
     F16,
-    Float3,
 }
 
 #[derive(Debug)]
@@ -164,13 +164,7 @@ impl GridDescriptor {
     }
 
     pub fn leaf_data_type(&self) -> LeafDataType {
-        let type_string = self
-            .meta_data
-            .0
-            .get("value_type")
-            .expect("Can not extract Grid value type!");
-        dbg!(type_string);
-        if let MetadataValue::String(s) = type_string {
+        if let Some(MetadataValue::String(s)) = self.meta_data.0.get("value_type") {
             if s == "float" {
                 if self.meta_data.is_half_float() {
                     LeafDataType::F16
@@ -181,7 +175,12 @@ impl GridDescriptor {
                 unimplemented!();
             }
         } else {
-            panic!("Expected value_type metadata as string format");
+            // Default to float as we've found instances of VDB volumes without `value_type` for their grids.
+            if self.meta_data.is_half_float() {
+                LeafDataType::F16
+            } else {
+                LeafDataType::F32
+            }
         }
     }
 }

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -15,7 +15,7 @@ pub enum GridMetadataError {
     FieldNotPresent(String),
 }
 
-pub enum DataType {
+pub enum LeafDataType {
     F32,
     F16,
     Float3,
@@ -103,7 +103,6 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let (Some(idx), Some(node_3)) = (self.node_3_iter.next(), self.node_3) {
-                // TODO: Cast when GridIter is created? Not at every iteration? Or is that not an issue?
                 let v = bytemuck::cast_slice::<u8, ValueTy>(&node_3.buffer)[idx];
                 let global_coord = node_3.offset_to_global_coord(Index(idx as u32));
                 let c = global_coord.0.as_vec3();
@@ -164,18 +163,19 @@ impl GridDescriptor {
         reader.seek(SeekFrom::Start(self.block_pos))
     }
 
-    pub fn data_type(&self) -> DataType {
+    pub fn data_type(&self) -> LeafDataType {
         let type_string = self
             .meta_data
             .0
             .get("value_type")
             .expect("Can not extract Grid value type!");
+        dbg!(type_string);
         if let MetadataValue::String(s) = type_string {
             if s == "float" {
                 if self.meta_data.is_half_float() {
-                    DataType::F16
+                    LeafDataType::F16
                 } else {
-                    DataType::F32
+                    LeafDataType::F32
                 }
             } else {
                 unimplemented!();

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -163,7 +163,7 @@ impl GridDescriptor {
         reader.seek(SeekFrom::Start(self.block_pos))
     }
 
-    pub fn data_type(&self) -> LeafDataType {
+    pub fn leaf_data_type(&self) -> LeafDataType {
         let type_string = self
             .meta_data
             .0

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -21,6 +21,12 @@ pub enum LeafDataType {
     F16,
 }
 
+// TODO: Only implemented the types I could find in a file up until now
+pub enum GridIterVariant<'a> {
+    F32(GridIter<'a, f32>),
+    F16(GridIter<'a, half::f16>),
+}
+
 #[derive(Debug)]
 pub struct Grid {
     pub tree: Tree,
@@ -29,19 +35,35 @@ pub struct Grid {
 }
 
 impl Grid {
-    pub fn iter<ValueTy: Pod>(&self) -> GridIter<'_, ValueTy> {
-        GridIter {
-            grid: self,
-            root_idx: 0,
-            node_5_iter: Default::default(),
-            node_4_iter: Default::default(),
-            node_3_iter: Default::default(),
+    pub fn iter(&self) -> GridIterVariant {
+        let data_type = self.grid_descriptor.leaf_data_type();
+        match data_type {
+            LeafDataType::F32 => GridIterVariant::F32(GridIter {
+                grid: self,
+                root_idx: 0,
+                node_5_iter: Default::default(),
+                node_4_iter: Default::default(),
+                node_3_iter: Default::default(),
 
-            node_5: None,
-            node_4: None,
-            node_3: None,
+                node_5: None,
+                node_4: None,
+                node_3: None,
 
-            phantom: PhantomData::<ValueTy>,
+                phantom: PhantomData::<f32>,
+            }),
+            LeafDataType::F16 => GridIterVariant::F16(GridIter {
+                grid: self,
+                root_idx: 0,
+                node_5_iter: Default::default(),
+                node_4_iter: Default::default(),
+                node_3_iter: Default::default(),
+
+                node_5: None,
+                node_4: None,
+                node_3: None,
+
+                phantom: PhantomData::<half::f16>,
+            }),
         }
     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -4,7 +4,7 @@ use crate::data_structure::{
     Node5, NodeHeader, NodeMetaData, Tree,
 };
 use crate::transform::Map;
-use crate::DataType;
+use crate::LeafDataType;
 
 use bitvec::prelude::*;
 use blosc_src::blosc_cbuffer_sizes;
@@ -212,7 +212,7 @@ impl<R: Read + Seek> VdbReader<R> {
         };
 
         let data = match gd.data_type() {
-            DataType::F32 => {
+            LeafDataType::F32 => {
                 let data = Self::read_compressed::<f32>(
                     reader,
                     header,
@@ -222,7 +222,7 @@ impl<R: Read + Seek> VdbReader<R> {
                 )?;
                 bytemuck::cast_slice::<f32, u8>(&data).to_vec()
             }
-            DataType::F16 => {
+            LeafDataType::F16 => {
                 let data = Self::read_compressed::<f16>(
                     reader,
                     header,
@@ -232,7 +232,7 @@ impl<R: Read + Seek> VdbReader<R> {
                 )?;
                 bytemuck::cast_slice::<f16, u8>(&data).to_vec()
             }
-            DataType::Float3 => todo!(),
+            LeafDataType::Float3 => todo!(),
         };
 
         Ok(NodeHeader {
@@ -554,7 +554,7 @@ impl<R: Read + Seek> VdbReader<R> {
                     }
 
                     let data = match gd.data_type() {
-                        DataType::F32 => {
+                        LeafDataType::F32 => {
                             let data = Self::read_compressed::<f32>(
                                 reader,
                                 header,
@@ -564,7 +564,7 @@ impl<R: Read + Seek> VdbReader<R> {
                             )?;
                             bytemuck::cast_slice::<f32, u8>(&data).to_vec()
                         }
-                        DataType::F16 => {
+                        LeafDataType::F16 => {
                             let data = Self::read_compressed::<f16>(
                                 reader,
                                 header,
@@ -574,7 +574,7 @@ impl<R: Read + Seek> VdbReader<R> {
                             )?;
                             bytemuck::cast_slice::<f16, u8>(&data).to_vec()
                         }
-                        DataType::Float3 => todo!(),
+                        LeafDataType::Float3 => todo!(),
                     };
 
                     node_3.buffer = data;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -13,7 +13,7 @@ use byteorder::{LittleEndian, ReadBytesExt};
 
 use half::f16;
 use log::{trace, warn};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::{Read, Seek, SeekFrom};
 
 pub const OPENVDB_MIN_SUPPORTED_VERSION: u32 = OPENVDB_FILE_VERSION_ROOTNODE_MAP;
@@ -81,7 +81,7 @@ fn read_i_vec3<R: Read + Seek>(reader: &mut R) -> Result<glam::IVec3, ParseError
 pub struct VdbReader<R: Read + Seek> {
     reader: R,
     pub header: ArchiveHeader,
-    pub grid_descriptors: HashMap<String, GridDescriptor>,
+    pub grid_descriptors: BTreeMap<String, GridDescriptor>,
 }
 
 impl<R: Read + Seek> VdbReader<R> {
@@ -615,11 +615,11 @@ impl<R: Read + Seek> VdbReader<R> {
     fn read_grid_descriptors(
         header: &ArchiveHeader,
         reader: &mut R,
-    ) -> Result<HashMap<String, GridDescriptor>, ParseError> {
+    ) -> Result<BTreeMap<String, GridDescriptor>, ParseError> {
         // Should be guaranteed by minimum file version
         assert!(header.has_grid_offsets);
 
-        let mut result = HashMap::new();
+        let mut result = BTreeMap::new();
         for _ in 0..header.grid_count {
             let name = Self::read_name(reader)?;
             let grid_type = Self::read_name(reader)?;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -211,7 +211,7 @@ impl<R: Read + Seek> VdbReader<R> {
             (1 << (3 * log_2_dim)) as usize
         };
 
-        let data = match gd.data_type() {
+        let data = match gd.leaf_data_type() {
             LeafDataType::F32 => {
                 let data = Self::read_compressed::<f32>(
                     reader,
@@ -553,7 +553,7 @@ impl<R: Read + Seek> VdbReader<R> {
                         assert_eq!(num_buffers, 1);
                     }
 
-                    let data = match gd.data_type() {
+                    let data = match gd.leaf_data_type() {
                         LeafDataType::F32 => {
                             let data = Self::read_compressed::<f32>(
                                 reader,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -585,7 +585,6 @@ impl<R: Read + Seek> VdbReader<R> {
                     Self::read_tree_data::<f16>(header, &gd, reader, &mut tree)?;
                     tree
                 }
-                LeafDataType::Float3 => todo!(),
             };
 
             Ok(Grid {


### PR DESCRIPTION
This moves the crate towards a less strongly-typed design and more towards the original OpenVDB vision. Grids are loaded and the data is stored as raw bytes. The choice of how to interpret those bytes can then be done at iteration time, according to the types reported in the grid descriptors.

Drive by changes:
- Store `GridDescriptor` in `BTreeMap` so that consecutive executions of the example app always return the grids in the same order.