### PR TITLE
🚚 Move `GridDescriptor`'s metadata accessors to its implementation 

### DIFF
--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -34,40 +34,6 @@ impl<ValueTy> Grid<ValueTy> {
             node_3: None,
         }
     }
-
-    // below values should always be present, see https://github.com/AcademySoftwareFoundation/openvdb/blob/master/openvdb/openvdb/Grid.cc#L387
-    pub fn aabb_min(&self) -> Result<IVec3, GridMetadataError> {
-        match self.descriptor.meta_data.0["file_bbox_min"] {
-            MetadataValue::Vec3i(v) => Ok(v),
-            _ => Err(GridMetadataError::FieldNotPresent(
-                "file_bbox_min".to_string(),
-            )),
-        }
-    }
-    pub fn aabb_max(&self) -> Result<IVec3, GridMetadataError> {
-        match self.descriptor.meta_data.0["file_bbox_max"] {
-            MetadataValue::Vec3i(v) => Ok(v),
-            _ => Err(GridMetadataError::FieldNotPresent(
-                "file_bbox_max".to_string(),
-            )),
-        }
-    }
-    pub fn mem_bytes(&self) -> Result<i64, GridMetadataError> {
-        match self.descriptor.meta_data.0["file_mem_bytes"] {
-            MetadataValue::I64(v) => Ok(v),
-            _ => Err(GridMetadataError::FieldNotPresent(
-                "file_mem_bytes".to_string(),
-            )),
-        }
-    }
-    pub fn voxel_count(&self) -> Result<i64, GridMetadataError> {
-        match self.descriptor.meta_data.0["file_voxel_count"] {
-            MetadataValue::I64(v) => Ok(v),
-            _ => Err(GridMetadataError::FieldNotPresent(
-                "file_voxel_count".to_string(),
-            )),
-        }
-    }
 }
 
 pub struct GridIter<'a, ValueTy> {
@@ -149,6 +115,40 @@ impl GridDescriptor {
         reader: &mut R,
     ) -> Result<u64, std::io::Error> {
         reader.seek(SeekFrom::Start(self.block_pos))
+    }
+
+    // below values should always be present, see https://github.com/AcademySoftwareFoundation/openvdb/blob/master/openvdb/openvdb/Grid.cc#L387
+    pub fn aabb_min(&self) -> Result<IVec3, GridMetadataError> {
+        match self.meta_data.0["file_bbox_min"] {
+            MetadataValue::Vec3i(v) => Ok(v),
+            _ => Err(GridMetadataError::FieldNotPresent(
+                "file_bbox_min".to_string(),
+            )),
+        }
+    }
+    pub fn aabb_max(&self) -> Result<IVec3, GridMetadataError> {
+        match self.meta_data.0["file_bbox_max"] {
+            MetadataValue::Vec3i(v) => Ok(v),
+            _ => Err(GridMetadataError::FieldNotPresent(
+                "file_bbox_max".to_string(),
+            )),
+        }
+    }
+    pub fn mem_bytes(&self) -> Result<i64, GridMetadataError> {
+        match self.meta_data.0["file_mem_bytes"] {
+            MetadataValue::I64(v) => Ok(v),
+            _ => Err(GridMetadataError::FieldNotPresent(
+                "file_mem_bytes".to_string(),
+            )),
+        }
+    }
+    pub fn voxel_count(&self) -> Result<i64, GridMetadataError> {
+        match self.meta_data.0["file_voxel_count"] {
+            MetadataValue::I64(v) => Ok(v),
+            _ => Err(GridMetadataError::FieldNotPresent(
+                "file_voxel_count".to_string(),
+            )),
+        }
     }
 }
 


### PR DESCRIPTION
They have no reason to live within the `Grid` implementation