### PR TITLE
🫠 Add multilevel iterator which fixes VDB tiles

### DIFF
--- a/examples/bevy.rs
+++ b/examples/bevy.rs
@@ -62,7 +62,7 @@ fn setup(mut commands: Commands, mut color_options_map: ResMut<CuboidMaterialMap
         .map(|(pos, voxel, level)| {
             Cuboid::new(
                 pos * 0.1,
-                (pos + Vec3::new(1.0, 1.0, 1.0) * level.scale()) * 0.1,
+                (pos + Vec3::splat(level.scale())) * 0.1,
                 u32::from_le_bytes(f32::to_le_bytes(voxel.to_f32())),
             )
         })

--- a/examples/bevy.rs
+++ b/examples/bevy.rs
@@ -59,7 +59,7 @@ fn setup(mut commands: Commands, mut color_options_map: ResMut<CuboidMaterialMap
     let grid = vdb_reader.read_grid::<half::f16>(&grid_to_load).unwrap();
     let instances: Vec<Cuboid> = grid
         .iter()
-        .map(|(pos, voxel)| {
+        .map(|(pos, voxel, _)| {
             Cuboid::new(
                 pos * 0.1,
                 (pos + Vec3::new(1.0, 1.0, 1.0)) * 0.1,

--- a/examples/bevy.rs
+++ b/examples/bevy.rs
@@ -62,7 +62,7 @@ fn setup(mut commands: Commands, mut color_options_map: ResMut<CuboidMaterialMap
         .map(|(pos, voxel, level)| {
             Cuboid::new(
                 pos * 0.1,
-                (pos + Vec3::splat(level.scale())) * 0.1,
+                (pos + level.scale()) * 0.1,
                 u32::from_le_bytes(f32::to_le_bytes(voxel.to_f32())),
             )
         })

--- a/examples/bevy.rs
+++ b/examples/bevy.rs
@@ -59,10 +59,10 @@ fn setup(mut commands: Commands, mut color_options_map: ResMut<CuboidMaterialMap
     let grid = vdb_reader.read_grid::<half::f16>(&grid_to_load).unwrap();
     let instances: Vec<Cuboid> = grid
         .iter()
-        .map(|(pos, voxel, _)| {
+        .map(|(pos, voxel, level)| {
             Cuboid::new(
                 pos * 0.1,
-                (pos + Vec3::new(1.0, 1.0, 1.0)) * 0.1,
+                (pos + Vec3::new(1.0, 1.0, 1.0) * level.scale()) * 0.1,
                 u32::from_le_bytes(f32::to_le_bytes(voxel.to_f32())),
             )
         })

--- a/examples/bevy.rs
+++ b/examples/bevy.rs
@@ -59,7 +59,7 @@ fn setup(mut commands: Commands, mut color_options_map: ResMut<CuboidMaterialMap
     let grid = vdb_reader.read_grid::<half::f16>(&grid_to_load).unwrap();
     let instances: Vec<Cuboid> = grid
         .iter()
-        .map(|(pos, voxel, _)| {
+        .map(|(pos, voxel)| {
             Cuboid::new(
                 pos * 0.1,
                 (pos + Vec3::new(1.0, 1.0, 1.0)) * 0.1,

--- a/examples/slicer.rs
+++ b/examples/slicer.rs
@@ -24,9 +24,9 @@ enum SliceAxis {
 impl SliceAxis {
     pub fn unit_vec(self) -> Vec3 {
         match self {
-            SliceAxis::X => vec3(1.0, 0.0, 0.0),
-            SliceAxis::Y => vec3(0.0, 1.0, 0.0),
-            SliceAxis::Z => vec3(0.0, 0.0, 1.0),
+            SliceAxis::X => Vec3::X,
+            SliceAxis::Y => Vec3::Y,
+            SliceAxis::Z => Vec3::Z,
         }
     }
 }
@@ -152,10 +152,11 @@ fn rebuild_model(
             .iter()
             .filter_map(|(mut pos, voxel, level)| {
                 // If our voxel intersects the slice index, we have to move it there to properly evaluate the reject_fn
-                let level_invariate_position = ((pos / level.scale()).floor()
+                let brick_starting_pos = ((pos / level.scale()).floor()
                     + if slice_index.is_negative() { 1.0 } else { 0.0 })
-                    * level.scale()
-                    + (slice_index % level.scale() as i32) as f32;
+                    * level.scale();
+                let slice_local_offset = (slice_index % level.scale() as i32) as f32;
+                let level_invariate_position = brick_starting_pos + slice_local_offset;
                 if reject_fn(level_invariate_position, level) {
                     None
                 } else {

--- a/examples/slicer.rs
+++ b/examples/slicer.rs
@@ -151,7 +151,10 @@ fn rebuild_model(
             .grid
             .iter()
             .filter_map(|(mut pos, voxel, level)| {
-                let level_invariate_position = (pos / level.scale()).floor() * level.scale()
+                // If our voxel intersects the slice index, we have to move it there to properly evaluate the reject_fn
+                let level_invariate_position = ((pos / level.scale()).floor()
+                    + if slice_index.is_negative() { 1.0 } else { 0.0 })
+                    * level.scale()
                     + (slice_index % level.scale() as i32) as f32;
                 if reject_fn(level_invariate_position, level) {
                     None

--- a/examples/slicer.rs
+++ b/examples/slicer.rs
@@ -24,9 +24,9 @@ enum SliceAxis {
 impl SliceAxis {
     pub fn unit_vec(self) -> Vec3 {
         match self {
-            SliceAxis::X => Vec3::X,
-            SliceAxis::Y => Vec3::Y,
-            SliceAxis::Z => Vec3::Z,
+            Self::X => Vec3::X,
+            Self::Y => Vec3::Y,
+            Self::Z => Vec3::Z,
         }
     }
 }
@@ -170,7 +170,7 @@ fn rebuild_model(
                     let pos = pos + translation;
                     Some(Cuboid::new(
                         pos * 0.1,
-                        (pos + Vec3::new(1.0, 1.0, 1.0) * dimension_mult) * 0.1,
+                        (pos + dimension_mult) * 0.1,
                         u32::from_le_bytes(f32::to_le_bytes(voxel.to_f32())),
                     ))
                 }

--- a/examples/slicer.rs
+++ b/examples/slicer.rs
@@ -21,12 +21,12 @@ enum SliceAxis {
     Z,
 }
 
-impl SliceAxis {
-    pub fn unit_vec(self) -> Vec3 {
-        match self {
-            Self::X => Vec3::X,
-            Self::Y => Vec3::Y,
-            Self::Z => Vec3::Z,
+impl From<SliceAxis> for Vec3 {
+    fn from(value: SliceAxis) -> Self {
+        match value {
+            SliceAxis::X => Vec3::X,
+            SliceAxis::Y => Vec3::Y,
+            SliceAxis::Z => Vec3::Z,
         }
     }
 }
@@ -162,7 +162,7 @@ fn rebuild_model(
                 } else {
                     let mut dimension_mult = Vec3::ONE;
                     if let RenderMode::Slice(i) = settings.render_mode {
-                        dimension_mult -= i.unit_vec();
+                        dimension_mult -= Vec3::from(i);
                         pos[i as usize] = slice_index as f32;
                     }
                     dimension_mult = (dimension_mult * level.scale()).max(Vec3::ONE);

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -38,7 +38,7 @@ impl<ValueTy> Grid<ValueTy> {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum VdbLevel {
     Node5,
     Node4,

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -109,7 +109,7 @@ where
             {
                 return Some((
                     node_5.offset_to_global_coord(Index(idx as u32)).0.as_vec3(),
-                    *node_5.data.get(idx).unwrap(),
+                    node_5.data[idx],
                     VdbLevel::Node4,
                 ));
             }

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -25,11 +25,9 @@ impl<ValueTy> Grid<ValueTy> {
         GridIter {
             grid: self,
             root_idx: 0,
-            node_5_iter_active: Default::default(),
-            node_5_iter_child: Default::default(),
-            node_4_iter_active: Default::default(),
-            node_4_iter_child: Default::default(),
-            node_3_iter_child: Default::default(),
+            node_5_iter: Default::default(),
+            node_4_iter: Default::default(),
+            node_3_iter: Default::default(),
 
             node_5: None,
             node_4: None,
@@ -38,32 +36,12 @@ impl<ValueTy> Grid<ValueTy> {
     }
 }
 
-#[derive(Clone, Copy)]
-pub enum VdbLevel {
-    Node5,
-    Node4,
-    Node3,
-    Voxel,
-}
-impl VdbLevel {
-    pub fn scale(self) -> f32 {
-        match self {
-            VdbLevel::Node5 => (1 << 5) as f32,
-            VdbLevel::Node4 => (1 << 4) as f32,
-            VdbLevel::Node3 => (1 << 3) as f32,
-            VdbLevel::Voxel => 1.0,
-        }
-    }
-}
-
 pub struct GridIter<'a, ValueTy> {
     grid: &'a Grid<ValueTy>,
     root_idx: usize,
-    node_5_iter_active: IterOnes<'a, u64, Lsb0>,
-    node_5_iter_child: IterOnes<'a, u64, Lsb0>,
-    node_4_iter_active: IterOnes<'a, u64, Lsb0>,
-    node_4_iter_child: IterOnes<'a, u64, Lsb0>,
-    node_3_iter_child: IterOnes<'a, u64, Lsb0>,
+    node_5_iter: IterOnes<'a, u64, Lsb0>,
+    node_4_iter: IterOnes<'a, u64, Lsb0>,
+    node_3_iter: IterOnes<'a, u64, Lsb0>,
 
     node_5: Option<&'a Node5<ValueTy>>,
     node_4: Option<&'a Node4<ValueTy>>,
@@ -74,36 +52,31 @@ impl<'a, ValueTy> Iterator for GridIter<'a, ValueTy>
 where
     ValueTy: Copy,
 {
-    type Item = (Vec3, ValueTy, VdbLevel);
+    type Item = (Vec3, ValueTy);
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if let (Some(idx), Some(node_3)) = (self.node_3_iter_child.next(), self.node_3) {
+            if let (Some(idx), Some(node_3)) = (self.node_3_iter.next(), self.node_3) {
                 let v = node_3.buffer[idx];
                 let global_coord = node_3.offset_to_global_coord(Index(idx as u32));
                 let c = global_coord.0.as_vec3();
-                return Some((c, v, VdbLevel::Voxel));
+                return Some((c, v));
             }
-            if let (Some(idx), Some(node_4)) = (self.node_4_iter_active.next(), self.node_4) {
-                if self.node_4_iter_child. {
-
-                }
+            if let (Some(idx), Some(node_4)) = (self.node_4_iter.next(), self.node_4) {
                 let node_3 = &node_4.nodes[&(idx as u32)];
-                self.node_3_iter_child = node_3.value_mask.iter_ones();
+                self.node_3_iter = node_3.value_mask.iter_ones();
                 self.node_3 = Some(node_3);
                 continue;
             }
-            if let (Some(idx), Some(node_5)) = (self.node_5_iter_child.next(), self.node_5) {
+            if let (Some(idx), Some(node_5)) = (self.node_5_iter.next(), self.node_5) {
                 let node_4 = &node_5.nodes[&(idx as u32)];
-                self.node_4_iter_active = node_4.value_mask.iter_ones();
-                self.node_4_iter_child = node_4.child_mask.iter_ones();
+                self.node_4_iter = node_4.child_mask.iter_ones();
                 self.node_4 = Some(node_4);
                 continue;
             }
             if self.root_idx < self.grid.tree.root_nodes.len() {
                 let node_5 = &self.grid.tree.root_nodes[self.root_idx];
-                self.node_5_iter_active = node_5.value_mask.iter_ones();
-                self.node_5_iter_child = node_5.child_mask.iter_ones();
+                self.node_5_iter = node_5.child_mask.iter_ones();
                 self.node_5 = Some(node_5);
                 self.root_idx += 1;
                 continue;

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -25,9 +25,11 @@ impl<ValueTy> Grid<ValueTy> {
         GridIter {
             grid: self,
             root_idx: 0,
-            node_5_iter: Default::default(),
-            node_4_iter: Default::default(),
-            node_3_iter: Default::default(),
+            node_5_iter_active: Default::default(),
+            node_5_iter_child: Default::default(),
+            node_4_iter_active: Default::default(),
+            node_4_iter_child: Default::default(),
+            node_3_iter_child: Default::default(),
 
             node_5: None,
             node_4: None,
@@ -36,12 +38,32 @@ impl<ValueTy> Grid<ValueTy> {
     }
 }
 
+#[derive(Clone, Copy)]
+pub enum VdbLevel {
+    Node5,
+    Node4,
+    Node3,
+    Voxel,
+}
+impl VdbLevel {
+    pub fn scale(self) -> f32 {
+        match self {
+            VdbLevel::Node5 => (1 << 5) as f32,
+            VdbLevel::Node4 => (1 << 4) as f32,
+            VdbLevel::Node3 => (1 << 3) as f32,
+            VdbLevel::Voxel => 1.0,
+        }
+    }
+}
+
 pub struct GridIter<'a, ValueTy> {
     grid: &'a Grid<ValueTy>,
     root_idx: usize,
-    node_5_iter: IterOnes<'a, u64, Lsb0>,
-    node_4_iter: IterOnes<'a, u64, Lsb0>,
-    node_3_iter: IterOnes<'a, u64, Lsb0>,
+    node_5_iter_active: IterOnes<'a, u64, Lsb0>,
+    node_5_iter_child: IterOnes<'a, u64, Lsb0>,
+    node_4_iter_active: IterOnes<'a, u64, Lsb0>,
+    node_4_iter_child: IterOnes<'a, u64, Lsb0>,
+    node_3_iter_child: IterOnes<'a, u64, Lsb0>,
 
     node_5: Option<&'a Node5<ValueTy>>,
     node_4: Option<&'a Node4<ValueTy>>,
@@ -52,31 +74,36 @@ impl<'a, ValueTy> Iterator for GridIter<'a, ValueTy>
 where
     ValueTy: Copy,
 {
-    type Item = (Vec3, ValueTy);
+    type Item = (Vec3, ValueTy, VdbLevel);
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if let (Some(idx), Some(node_3)) = (self.node_3_iter.next(), self.node_3) {
+            if let (Some(idx), Some(node_3)) = (self.node_3_iter_child.next(), self.node_3) {
                 let v = node_3.buffer[idx];
                 let global_coord = node_3.offset_to_global_coord(Index(idx as u32));
                 let c = global_coord.0.as_vec3();
-                return Some((c, v));
+                return Some((c, v, VdbLevel::Voxel));
             }
-            if let (Some(idx), Some(node_4)) = (self.node_4_iter.next(), self.node_4) {
+            if let (Some(idx), Some(node_4)) = (self.node_4_iter_active.next(), self.node_4) {
+                if self.node_4_iter_child. {
+
+                }
                 let node_3 = &node_4.nodes[&(idx as u32)];
-                self.node_3_iter = node_3.value_mask.iter_ones();
+                self.node_3_iter_child = node_3.value_mask.iter_ones();
                 self.node_3 = Some(node_3);
                 continue;
             }
-            if let (Some(idx), Some(node_5)) = (self.node_5_iter.next(), self.node_5) {
+            if let (Some(idx), Some(node_5)) = (self.node_5_iter_child.next(), self.node_5) {
                 let node_4 = &node_5.nodes[&(idx as u32)];
-                self.node_4_iter = node_4.child_mask.iter_ones();
+                self.node_4_iter_active = node_4.value_mask.iter_ones();
+                self.node_4_iter_child = node_4.child_mask.iter_ones();
                 self.node_4 = Some(node_4);
                 continue;
             }
             if self.root_idx < self.grid.tree.root_nodes.len() {
                 let node_5 = &self.grid.tree.root_nodes[self.root_idx];
-                self.node_5_iter = node_5.child_mask.iter_ones();
+                self.node_5_iter_active = node_5.value_mask.iter_ones();
+                self.node_5_iter_child = node_5.child_mask.iter_ones();
                 self.node_5 = Some(node_5);
                 self.root_idx += 1;
                 continue;

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -26,9 +26,9 @@ impl<ValueTy> Grid<ValueTy> {
             grid: self,
             root_idx: 0,
             node_5_iter_active: Default::default(),
-            node_5_iter_child: Default::default(),
+            node_5_child: Default::default(),
             node_4_iter_active: Default::default(),
-            node_4_iter_child: Default::default(),
+            node_4_child: Default::default(),
             node_3_iter_child: Default::default(),
 
             node_5: None,
@@ -60,9 +60,9 @@ pub struct GridIter<'a, ValueTy> {
     grid: &'a Grid<ValueTy>,
     root_idx: usize,
     node_5_iter_active: IterOnes<'a, u64, Lsb0>,
-    node_5_iter_child: IterOnes<'a, u64, Lsb0>,
+    node_5_child: Option<&'a BitVec<u64, Lsb0>>,
     node_4_iter_active: IterOnes<'a, u64, Lsb0>,
-    node_4_iter_child: IterOnes<'a, u64, Lsb0>,
+    node_4_child: Option<&'a BitVec<u64, Lsb0>>,
     node_3_iter_child: IterOnes<'a, u64, Lsb0>,
 
     node_5: Option<&'a Node5<ValueTy>>,
@@ -82,30 +82,60 @@ where
                 let v = node_3.buffer[idx];
                 let global_coord = node_3.offset_to_global_coord(Index(idx as u32));
                 let c = global_coord.0.as_vec3();
+                println!("voxel");
                 return Some((c, v, VdbLevel::Voxel));
             }
-            if let (Some(idx), Some(node_4)) = (self.node_4_iter_active.next(), self.node_4) {
-                if self.node_4_iter_child. {
-
+            if let (Some(idx), Some(node_4), Some(node_4_child)) = (
+                self.node_4_iter_active.next(),
+                self.node_4,
+                self.node_4_child,
+            ) {
+                if *node_4_child.get(idx).unwrap() {
+                    let node_3 = &node_4.nodes[&(idx as u32)];
+                    self.node_3_iter_child = node_3.value_mask.iter_ones();
+                    self.node_3 = Some(node_3);
+                    println!("set node 3");
+                    continue;
+                } else {
+                    println!("voxel node 3");
+                    return Some((
+                        node_4.offset_to_global_coord(Index(idx as u32)).0.as_vec3(),
+                        *node_4.data.get(idx).unwrap(),
+                        VdbLevel::Node3,
+                    ));
                 }
-                let node_3 = &node_4.nodes[&(idx as u32)];
-                self.node_3_iter_child = node_3.value_mask.iter_ones();
-                self.node_3 = Some(node_3);
-                continue;
             }
-            if let (Some(idx), Some(node_5)) = (self.node_5_iter_child.next(), self.node_5) {
-                let node_4 = &node_5.nodes[&(idx as u32)];
-                self.node_4_iter_active = node_4.value_mask.iter_ones();
-                self.node_4_iter_child = node_4.child_mask.iter_ones();
-                self.node_4 = Some(node_4);
-                continue;
+            if let (Some(idx), Some(node_5), Some(node_5_child)) = (
+                self.node_5_iter_active.next(),
+                self.node_5,
+                self.node_5_child,
+            ) {
+                if *node_5_child.get(idx).unwrap() {
+                    let node_4 = &node_5.nodes[&(idx as u32)];
+                    self.node_4_iter_active = node_4.value_mask.iter_ones();
+                    self.node_4_child = Some(&node_4.child_mask);
+                    self.node_4 = Some(node_4);
+                    println!("set node 4");
+                    continue;
+                } else {
+                    println!("voxel node 4");
+                    return Some((
+                        node_5.offset_to_global_coord(Index(idx as u32)).0.as_vec3(),
+                        *node_5.data.get(idx).unwrap(),
+                        VdbLevel::Node4,
+                    ));
+                }
             }
+
             if self.root_idx < self.grid.tree.root_nodes.len() {
                 let node_5 = &self.grid.tree.root_nodes[self.root_idx];
                 self.node_5_iter_active = node_5.value_mask.iter_ones();
-                self.node_5_iter_child = node_5.child_mask.iter_ones();
+                println!("{}", node_5.value_mask.count_ones());
+                println!("{}", node_5.child_mask.count_ones());
+                self.node_5_child = Some(&node_5.child_mask);
                 self.node_5 = Some(node_5);
                 self.root_idx += 1;
+                println!("set node 5");
                 continue;
             }
             return None;
@@ -268,6 +298,7 @@ pub struct Node4<ValueTy> {
     pub child_mask: BitVec<u64, Lsb0>,
     pub value_mask: BitVec<u64, Lsb0>,
     pub nodes: HashMap<u32, Node3<ValueTy>>,
+    pub data: Vec<ValueTy>,
     pub origin: glam::IVec3,
 }
 
@@ -285,6 +316,7 @@ pub struct Node5<ValueTy> {
     pub child_mask: BitVec<u64, Lsb0>,
     pub value_mask: BitVec<u64, Lsb0>,
     pub nodes: HashMap<u32, Node4<ValueTy>>,
+    pub data: Vec<ValueTy>,
     pub origin: glam::IVec3,
 }
 

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -40,7 +40,6 @@ impl<ValueTy> Grid<ValueTy> {
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum VdbLevel {
-    Node5,
     Node4,
     Node3,
     Voxel,
@@ -48,7 +47,6 @@ pub enum VdbLevel {
 impl VdbLevel {
     pub fn scale(self) -> f32 {
         match self {
-            VdbLevel::Node5 => (1 << 5) as f32,
             VdbLevel::Node4 => (1 << 4) as f32,
             VdbLevel::Node3 => (1 << 3) as f32,
             VdbLevel::Voxel => 1.0,

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -120,7 +120,6 @@ where
                 self.node_5_iter_child = node_5.child_mask.iter_ones();
                 self.node_5 = Some(node_5);
                 self.root_idx += 1;
-                println!("set node 5");
                 continue;
             }
             return None;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -473,6 +473,18 @@ impl<R: Read + Seek> VdbReader<R> {
 
             let node_5 =
                 Self::read_node_header::<ValueTy>(reader, 5 /* 32 * 32 * 32 */, header, gd)?;
+
+            assert!(
+                node_5
+                    .child_mask
+                    .iter()
+                    .zip(node_5.value_mask.iter())
+                    .map(|(bit1, bit2)| (*bit1 & *bit2) as u32)
+                    .sum::<u32>()
+                    == 0,
+                "intersection of child and acctive masks was not 0"
+            );
+
             let mut child_5 = HashMap::default();
 
             let mut root = Node5 {
@@ -488,6 +500,16 @@ impl<R: Read + Seek> VdbReader<R> {
                     reader, 4, /* 16 * 16 * 16 */
                     header, gd,
                 )?;
+                assert!(
+                    node_4
+                        .child_mask
+                        .iter()
+                        .zip(node_4.value_mask.iter())
+                        .map(|(bit1, bit2)| (*bit1 & *bit2) as u32)
+                        .sum::<u32>()
+                        == 0,
+                    "intersection of child and acctive masks was not 0"
+                );
                 let mut child_4 = HashMap::default();
 
                 let mut cur_node_4 = Node4 {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -473,7 +473,6 @@ impl<R: Read + Seek> VdbReader<R> {
 
             let node_5 =
                 Self::read_node_header::<ValueTy>(reader, 5 /* 32 * 32 * 32 */, header, gd)?;
-
             let mut child_5 = HashMap::default();
 
             let mut root = Node5 {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -479,6 +479,7 @@ impl<R: Read + Seek> VdbReader<R> {
                 child_mask: node_5.child_mask.clone(),
                 value_mask: node_5.value_mask.clone(),
                 nodes: Default::default(),
+                data: node_5.data,
                 origin,
             };
 
@@ -493,6 +494,7 @@ impl<R: Read + Seek> VdbReader<R> {
                     child_mask: node_4.child_mask.clone(),
                     value_mask: node_4.value_mask.clone(),
                     nodes: Default::default(),
+                    data: node_4.data,
                     origin: root.offset_to_global_coord(Index(idx as u32)).0,
                 };
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -474,17 +474,6 @@ impl<R: Read + Seek> VdbReader<R> {
             let node_5 =
                 Self::read_node_header::<ValueTy>(reader, 5 /* 32 * 32 * 32 */, header, gd)?;
 
-            assert!(
-                node_5
-                    .child_mask
-                    .iter()
-                    .zip(node_5.value_mask.iter())
-                    .map(|(bit1, bit2)| (*bit1 & *bit2) as u32)
-                    .sum::<u32>()
-                    == 0,
-                "intersection of child and acctive masks was not 0"
-            );
-
             let mut child_5 = HashMap::default();
 
             let mut root = Node5 {
@@ -500,16 +489,6 @@ impl<R: Read + Seek> VdbReader<R> {
                     reader, 4, /* 16 * 16 * 16 */
                     header, gd,
                 )?;
-                assert!(
-                    node_4
-                        .child_mask
-                        .iter()
-                        .zip(node_4.value_mask.iter())
-                        .map(|(bit1, bit2)| (*bit1 & *bit2) as u32)
-                        .sum::<u32>()
-                        == 0,
-                    "intersection of child and acctive masks was not 0"
-                );
                 let mut child_4 = HashMap::default();
 
                 let mut cur_node_4 = Node4 {


### PR DESCRIPTION
Tile data is now stored in the 4 and 5 nodes. This will also be iterated over. And these changes are visualized in the slicer, which can be seen below:


https://github.com/Traverse-Research/vdb-rs/assets/31817802/879c1d89-7332-4520-9763-c2d69a813878

