### PR TITLE
Fix node mask compression

### DIFF
--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -143,7 +143,7 @@ where
 #[derive(Debug, Clone)]
 pub struct GridDescriptor {
     pub name: String,
-    pub(crate) file_version: u32,
+    pub file_version: u32,
     /// If not empty, the name of another grid that shares this grid's tree
     pub instance_parent: String,
     pub grid_type: String,

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -92,12 +92,11 @@ where
                 continue;
             } else if let (Some(idx), Some(node_4)) = (self.node_4_iter_active.next(), self.node_4)
             {
-                println!("data len: {} value mask len: {} child mask len: {} idx: {} file version: {} node compression version: {}", node_4.data.len(), node_4.value_mask.len(), node_4.child_mask.len(), idx, self.grid.descriptor.file_version, OPENVDB_FILE_VERSION_NODE_MASK_COMPRESSION);
                 return Some((
                     node_4.offset_to_global_coord(Index(idx as u32)).0.as_vec3(),
-
                     if self.grid.descriptor.file_version < OPENVDB_FILE_VERSION_NODE_MASK_COMPRESSION {
-                        node_4.data[node_4.node_4_iter_active.iter_zeros().nth(idx).unwrap()]
+                        let node_mask_compression_idx = node_4.child_mask.iter().by_vals().take(idx).fold(0, |old, val| old + (!val as usize)); // count 0's before idx
+                        node_4.data[node_mask_compression_idx]
                     } else {
                         node_4.data[idx]
                     },

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -1,6 +1,6 @@
-use crate::OPENVDB_FILE_VERSION_NODE_MASK_COMPRESSION;
 use crate::coordinates::{GlobalCoord, Index, LocalCoord};
 use crate::transform::Map;
+use crate::OPENVDB_FILE_VERSION_NODE_MASK_COMPRESSION;
 use bitflags::bitflags;
 use bitvec::prelude::*;
 use bitvec::slice::IterOnes;
@@ -94,8 +94,15 @@ where
             {
                 return Some((
                     node_4.offset_to_global_coord(Index(idx as u32)).0.as_vec3(),
-                    if self.grid.descriptor.file_version < OPENVDB_FILE_VERSION_NODE_MASK_COMPRESSION {
-                        let node_mask_compression_idx = node_4.child_mask.iter().by_vals().take(idx).fold(0, |old, val| old + (!val as usize)); // count 0's before idx
+                    if self.grid.descriptor.file_version
+                        < OPENVDB_FILE_VERSION_NODE_MASK_COMPRESSION
+                    {
+                        let node_mask_compression_idx = node_4
+                            .child_mask
+                            .iter()
+                            .by_vals()
+                            .take(idx)
+                            .fold(0, |old, val| old + (!val as usize)); // count 0's before idx
                         node_4.data[node_mask_compression_idx]
                     } else {
                         node_4.data[idx]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -619,6 +619,7 @@ impl<R: Read + Seek> VdbReader<R> {
 
             let mut gd = GridDescriptor {
                 name: name.clone(),
+                file_version: header.file_version,
                 grid_type,
                 instance_parent,
                 grid_pos,


### PR DESCRIPTION
Some old files only store tile values when the child bit is set to 0, so when iterating over our data we should grab the tile values by indexing into the tile buffer with an index computed by counting the number of 0 bits before the usual bit index. This fixes tile value loading of bunny_cloud.vdb