### PR TITLE
Fix scale not using the span log

### DIFF
--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -48,7 +48,7 @@ pub enum VdbLevel {
 impl VdbLevel {
     pub fn scale(self) -> f32 {
         match self {
-            VdbLevel::Node4 => (1 << 4) as f32,
+            VdbLevel::Node4 => (1 << (4 + 3)) as f32,
             VdbLevel::Node3 => (1 << 3) as f32,
             VdbLevel::Voxel => 1.0,
         }


### PR DESCRIPTION
Pretty much exactly the title, the L2 scale was 8x too small.