### PR TITLE
🪅 Fix blosc loading

### DIFF
--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -69,7 +69,7 @@ pub struct GridIter<'a, ValueTy> {
     node_3: Option<&'a Node3<ValueTy>>,
 }
 
-impl<'a, ValueTy> Iterator for GridIter<'a, ValueTy>
+impl<ValueTy> Iterator for GridIter<'_, ValueTy>
 where
     ValueTy: Copy,
 {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -229,10 +229,10 @@ impl<R: Read + Seek> VdbReader<R> {
         gd: &GridDescriptor,
         count: usize,
     ) -> Result<Vec<T>, ParseError> {
+        if count <= 0 {
+            return Ok(vec![T::zeroed(); count as usize]);
+        }
         Ok(if gd.compression.contains(Compression::BLOSC) {
-            if count <= 0 {
-                return Ok(vec![T::zeroed(); count as usize]);
-            }
             let num_compressed_bytes = reader.read_i64::<LittleEndian>()?;
             let compressed_count = num_compressed_bytes / std::mem::size_of::<T>() as i64;
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -230,7 +230,7 @@ impl<R: Read + Seek> VdbReader<R> {
         count: usize,
     ) -> Result<Vec<T>, ParseError> {
         if count == 0 {
-            return Ok(vec![T::zeroed(); count]);
+            return Ok(Vec::new());
         }
         Ok(if gd.compression.contains(Compression::BLOSC) {
             let num_compressed_bytes = reader.read_i64::<LittleEndian>()?;
@@ -279,10 +279,7 @@ impl<R: Read + Seek> VdbReader<R> {
                         "Skipping blosc decompression because of a {}-count read",
                         count
                     );
-                    {
-                        T::zeroed();
-                        vec![] as std::vec::Vec<T>
-                    }
+                    Vec::new()
                 }
             }
         } else if gd.compression.contains(Compression::ZIP) {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -279,7 +279,10 @@ impl<R: Read + Seek> VdbReader<R> {
                         "Skipping blosc decompression because of a {}-count read",
                         count
                     );
-                    vec![T::zeroed(); 0]
+                    {
+                        T::zeroed();
+                        vec![] as std::vec::Vec<T>
+                    }
                 }
             }
         } else if gd.compression.contains(Compression::ZIP) {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -230,6 +230,9 @@ impl<R: Read + Seek> VdbReader<R> {
         count: usize,
     ) -> Result<Vec<T>, ParseError> {
         Ok(if gd.compression.contains(Compression::BLOSC) {
+            if count <= 0 {
+                return Ok(vec![T::zeroed(); count as usize]);
+            }
             let num_compressed_bytes = reader.read_i64::<LittleEndian>()?;
             let compressed_count = num_compressed_bytes / std::mem::size_of::<T>() as i64;
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -229,8 +229,8 @@ impl<R: Read + Seek> VdbReader<R> {
         gd: &GridDescriptor,
         count: usize,
     ) -> Result<Vec<T>, ParseError> {
-        if count <= 0 {
-            return Ok(vec![T::zeroed(); count as usize]);
+        if count == 0 {
+            return Ok(vec![T::zeroed(); count]);
         }
         Ok(if gd.compression.contains(Compression::BLOSC) {
             let num_compressed_bytes = reader.read_i64::<LittleEndian>()?;


### PR DESCRIPTION
For a while we have not been able to load blosc encoded files. But that time is no more. After a significant debugging session I found out that OpenVDB does hit this check https://github.com/AcademySoftwareFoundation/openvdb/blob/master/openvdb/openvdb/io/Compression.h#L308 and does an early out if count == 0. We didnt do this check resulting in us reading `num_compressed_bytes` from the reader, reading garbage and offsetting the reader incorrectly.

I validated the results against one frame of each of JangaFX's free download models, specifically the ones listed below:
![image](https://github.com/user-attachments/assets/49eaf3f2-e9ab-4f1c-96f7-8d1b3edbb84f)
All these models now load correctly. yay.

The main problematic files remaining are specific exports I made myself with Houdini. These models use f32 for the voxel values, unlike Embergen, which uses f16.

This PR fixes https://github.com/Traverse-Research/vdb-rs/issues/33